### PR TITLE
Removed invalid path from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "tslint": "^3.13.0"
   },
   "files": [
-    "dist",
-    "types/bazinga64.d.ts"
+    "dist"
   ],
   "homepage": "https://github.com/wireapp/bazinga64#readme",
   "keywords": [


### PR DESCRIPTION
It looks like it's already under `dist/typings/bazinga64.d.ts`.. :)